### PR TITLE
Log signal objects in sequential logging

### DIFF
--- a/logger_block.py
+++ b/logger_block.py
@@ -1,7 +1,7 @@
 from nio.block.base import Block
 from nio.command import command
 from nio.command.params.string import StringParameter
-from nio.properties import SelectProperty, BoolProperty
+from nio.properties import SelectProperty, BoolProperty, VersionProperty
 from nio.util.logging.levels import LogLevel
 
 
@@ -20,6 +20,7 @@ class Logger(Block):
     log_at = SelectProperty(LogLevel, title="Log At", default="INFO")
     log_as_list = BoolProperty(title="Log as a list",
                                default=False, visible=False)
+    version = VersionProperty("0.0.2")
 
     def process_signals(self, signals):
         """ Overridden from the block interface.

--- a/logger_block.py
+++ b/logger_block.py
@@ -51,7 +51,7 @@ class Logger(Block):
     def _log_signals_sequentially(self, log_func, signals):
         for s in signals:
             try:
-                log_func(s.to_dict())
+                log_func(s)
             except:
                 self.logger.exception("Failed to log signal")
 

--- a/logger_block.py
+++ b/logger_block.py
@@ -43,7 +43,7 @@ class Logger(Block):
 
     def _log_signals_as_list(self, log_func, signals):
         try:
-            log_func([signal.to_dict() for signal in signals])
+            log_func(str([signal.to_dict() for signal in signals]))
         except:
             self.logger.exception(
                 "Failed to log {} signals".format(len(signals)))
@@ -51,7 +51,7 @@ class Logger(Block):
     def _log_signals_sequentially(self, log_func, signals):
         for s in signals:
             try:
-                log_func(s)
+                log_func(str(s.to_dict()))
             except:
                 self.logger.exception("Failed to log signal")
 

--- a/logger_block.py
+++ b/logger_block.py
@@ -20,7 +20,7 @@ class Logger(Block):
     log_at = SelectProperty(LogLevel, title="Log At", default="INFO")
     log_as_list = BoolProperty(title="Log as a list",
                                default=False, visible=False)
-    version = VersionProperty("0.0.2")
+    version = VersionProperty("1.0.0")
 
     def process_signals(self, signals):
         """ Overridden from the block interface.

--- a/release.json
+++ b/release.json
@@ -1,7 +1,7 @@
 {
   "nio/Logger": {
     "language": "Python",
-    "version": "0.0.2",
-    "reference": "github.com/nio-blocks/logger.git@v0.0.2"
+    "version": "1.0.0",
+    "reference": "github.com/nio-blocks/logger.git@v1.0.0"
   }
 }

--- a/release.json
+++ b/release.json
@@ -1,7 +1,7 @@
 {
   "nio/Logger": {
     "language": "Python",
-    "version": "0.0.1",
-    "reference": "github.com/nio-blocks/logger.git@v0.0.1"
+    "version": "0.0.2",
+    "reference": "github.com/nio-blocks/logger.git@v0.0.2"
   }
 }

--- a/spec.json
+++ b/spec.json
@@ -1,6 +1,6 @@
 {
   "nio/Logger": {
-    "version": "0.0.2",
+    "version": "1.0.0",
     "description": "",
     "properties": {
       "log_as_list": {

--- a/spec.json
+++ b/spec.json
@@ -1,10 +1,40 @@
 {
   "nio/Logger": {
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "",
+    "properties": {
+      "log_as_list": {
+        "title": "Log as a list",
+        "type": "BoolType",
+        "description": "Whether to log incoming signals as lists. The default behavior is to log lists of incoming signals one at a time. Setting this to True allows one to see if the block received multiple signals at once or multiple signals sequentially.",
+        "default": false
+      },
+      "log_at": {
+        "title": "Log At",
+        "type": "SelectType",
+        "description": "The log level to log outgoing messages at. Default is INFO.",
+        "default": "INFO"
+      },
+      "log_level": {
+        "title": "Log Level",
+        "type": "SelectType",
+        "description": "Sets the log level for the block. Default is INFO.",
+        "default": "INFO"
+      }
+    },
     "inputs": {},
     "outputs": {},
-    "properties": {},
-    "commands": {}
+    "commands": {
+      "log": {
+        "params": {
+          "phrase": {
+            "default": "Default phrase",
+            "title": "phrase",
+            "allow_none": false
+          }
+        },
+        "description": ""
+      }
+    }
   }
 }

--- a/tests/test_logger_block.py
+++ b/tests/test_logger_block.py
@@ -43,7 +43,7 @@ class TestLogger(NIOBlockTestCase):
         blk.logger = MagicMock()
         signal = Signal({"I <3": "n.io"})
         blk.process_signals([signal])
-        blk.logger.info.assert_called_once_with(signal)
+        blk.logger.info.assert_called_once_with(str(signal.to_dict()))
         self.assertEqual(blk.logger.error.call_count, 0)
 
     def test_list_process_signals(self):
@@ -53,8 +53,8 @@ class TestLogger(NIOBlockTestCase):
         signal = Signal({"I <3": "n.io"})
         blk.process_signals([signal, signal])
         blk.logger.info.assert_has_calls([
-            call(signal),
-            call(signal),
+            call(str(signal.to_dict())),
+            call(str(signal.to_dict())),
         ])
         self.assertEqual(blk.logger.error.call_count, 0)
 
@@ -65,7 +65,7 @@ class TestLogger(NIOBlockTestCase):
         blk.logger.info.side_effect = Exception()
         signal = Signal({"I <3": "n.io"})
         blk.process_signals([signal])
-        blk.logger.info.assert_called_once_with(signal)
+        blk.logger.info.assert_called_once_with(str(signal.to_dict()))
         blk.logger.exception.assert_called_once_with("Failed to log signal")
 
     def test_list_logging(self):
@@ -74,8 +74,6 @@ class TestLogger(NIOBlockTestCase):
         blk.logger = MagicMock()
         signal = Signal({"I <3": "n.io"})
         blk.process_signals([signal, signal])
-        blk.logger.info.assert_called_once_with([
-            signal.to_dict(),
-            signal.to_dict(),
-        ])
+        blk.logger.info.assert_called_once_with("[{0}, {0}]"
+                                                .format(signal.to_dict()))
         self.assertEqual(blk.logger.error.call_count, 0)

--- a/tests/test_logger_block.py
+++ b/tests/test_logger_block.py
@@ -43,7 +43,7 @@ class TestLogger(NIOBlockTestCase):
         blk.logger = MagicMock()
         signal = Signal({"I <3": "n.io"})
         blk.process_signals([signal])
-        blk.logger.info.assert_called_once_with(signal.to_dict())
+        blk.logger.info.assert_called_once_with(signal)
         self.assertEqual(blk.logger.error.call_count, 0)
 
     def test_list_process_signals(self):
@@ -53,8 +53,8 @@ class TestLogger(NIOBlockTestCase):
         signal = Signal({"I <3": "n.io"})
         blk.process_signals([signal, signal])
         blk.logger.info.assert_has_calls([
-            call(signal.to_dict()),
-            call(signal.to_dict()),
+            call(signal),
+            call(signal),
         ])
         self.assertEqual(blk.logger.error.call_count, 0)
 
@@ -65,7 +65,7 @@ class TestLogger(NIOBlockTestCase):
         blk.logger.info.side_effect = Exception()
         signal = Signal({"I <3": "n.io"})
         blk.process_signals([signal])
-        blk.logger.info.assert_called_once_with(signal.to_dict())
+        blk.logger.info.assert_called_once_with(signal)
         blk.logger.exception.assert_called_once_with("Failed to log signal")
 
     def test_list_logging(self):


### PR DESCRIPTION
When we added the ability to log signals as a list ( #9 ), we decided when logging sequentially to explicitly log `s.to_dict()` for explicitness' sake. This was thought to be fine since when previously logging the signal object, `self.to_dict()` would implicitly be called when logging the object. This new behavior turned out to not play well in a docker container that Dave was running, giving the following error message which seems to expect a hashable object in caching but gets the dictionary instead:

```
[2017-08-09 14:43:03.575] NIO [ERROR] [Test Publisher.Test Log] Failed to log signal
Traceback (most recent call last):
  File "/nio/project/blocks/logger/logger_block.py", line 54, in _log_signals_sequentially
    log_func(s.to_dict())
  File "/usr/local/lib/python3.5/logging/__init__.py", line 1620, in error
    self.log(ERROR, msg, *args, **kwargs)
  File "/usr/local/lib/python3.5/logging/__init__.py", line 1641, in log
    self.logger._log(level, msg, args, **kwargs)
  File "/usr/local/lib/python3.5/logging/__init__.py", line 1416, in _log
    self.handle(record)
  File "/usr/local/lib/python3.5/logging/__init__.py", line 1426, in handle
    self.callHandlers(record)
  File "/usr/local/lib/python3.5/logging/__init__.py", line 1488, in callHandlers
    hdlr.handle(record)
  File "/usr/local/lib/python3.5/logging/__init__.py", line 852, in handle
    rv = self.filter(record)
  File "/usr/local/lib/python3.5/logging/__init__.py", line 711, in filter
    result = f.filter(record)
  File "/usr/local/lib/python3.5/site-packages/nio/util/logging/handlers/publisher/cache_filter.py", line 32, in filter
    return not self._log_cache.process_record(record)
  File "/usr/local/lib/python3.5/site-packages/nio/util/logging/handlers/publisher/cache.py", line 42, in process_record
    hash(record.msg))
TypeError: unhashable type: 'dict'
```
A note: it also successfully logs the signal in question directly beforehand (in the same millisecond)

I couldn't reproduce this in my local environment, making me think that the python install in the container uses logging a bit differently or a different nio version. However if this small change back to implicitness fixes the issue I think this is fine. 