### PR TITLE
Add log_as_list as default to Logger block

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 Logger
 ======
-The Logger blocks outputs incoming signals into the terminal and system designer's logger panel.
+The _Logger_ block sends incoming signals to display in the terminal and System Designer's logger panel.
 
 Properties
 ----------
-- **log_as_list**: Hidden property defaulted to `False`. Whether to log incoming signals as lists. The default behavior is to log lists of incoming signals one at a time. Setting this to True allows one to see if the block received multiple signals at once or multiple signals sequentially.
-- **log_at**: The log level that incoming signals show up as in the logs. Default is INFO.
-- **log_hidden_attributes**: If `True` (checked) the log output will include hidden (private) attributes denoted by a leading underscore (eg: `_signal_attribute`.
+- **log_as_list**: Whether to log incoming signals as lists. Default is `False` and each incoming signal list is logged one signal at a time. Setting this to `True` logs signals grouped inside their list.
+- **log_at**: The log level that determines the rank of log messages to display. Default is INFO.
+- **log_hidden_attributes**: If `True` (checked) the log output will include hidden (private) attributes denoted by a leading underscore (e.g., `_signal_attribute`.)
 
 Inputs
 ------

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The _Logger_ block sends incoming signals to display in the terminal and System 
 
 Properties
 ----------
-- **log_as_list**: Whether to log incoming signals as lists. Default is `False` and each incoming signal list is logged one signal at a time. Setting this to `True` logs signals grouped inside their list.
+- **log_as_list**: Hidden property to log incoming signals as lists. Default is `True` and signals are grouped inside their list. Setting this to `False` logs one signal at a time.
 - **log_at**: The log level that determines the rank of log messages to display. Default is INFO.
 - **log_hidden_attributes**: If `True` (checked) the log output will include hidden (private) attributes denoted by a leading underscore (e.g., `_signal_attribute`.)
 

--- a/logger_block.py
+++ b/logger_block.py
@@ -47,9 +47,9 @@ class Logger(TerminatorBlock):
 
     def _log_signals_as_list(self, log_func, signals):
         try:
-            log_func([
+            log_func('[{}]'.format(', '.join([
                 json.dumps(signal.to_dict(self.log_hidden_attributes()), default=str, sort_keys=True)
-                for signal in signals])
+                for signal in signals])))
         except:
             self.logger.exception(
                 "Failed to log {} signals".format(len(signals)))

--- a/logger_block.py
+++ b/logger_block.py
@@ -20,7 +20,8 @@ class Logger(TerminatorBlock):
     # block
     log_level = SelectProperty(LogLevel, title="Log Level", default="INFO")
     log_at = SelectProperty(LogLevel, title="Log At", default="INFO")
-    log_as_list = BoolProperty(title="Log as a List", default=False)
+    log_as_list = BoolProperty(title="Log as a List",
+                               default=True, visible=False)
     log_hidden_attributes = BoolProperty(title="Log Hidden Attributes",
                                          default=False)
     version = VersionProperty("1.1.1")
@@ -30,10 +31,10 @@ class Logger(TerminatorBlock):
 
         When an instance of Logger is in the receivers list for some
         other block, this method allows the sending block to deliver its
-        outgoing signal object to the logger, which logs them individually.
+        outgoing signal object to the logger, which logs them as a list.
 
         Args:
-            signals (list of Signal): a list of signals to be logged.
+            signals (list of Signals): a list of signals to be logged.
 
         Returns:
             None

--- a/logger_block.py
+++ b/logger_block.py
@@ -20,8 +20,7 @@ class Logger(TerminatorBlock):
     # block
     log_level = SelectProperty(LogLevel, title="Log Level", default="INFO")
     log_at = SelectProperty(LogLevel, title="Log At", default="INFO")
-    log_as_list = BoolProperty(title="Log as a list",
-                               default=False, visible=False)
+    log_as_list = BoolProperty(title="Log as a List", default=False)
     log_hidden_attributes = BoolProperty(title="Log Hidden Attributes",
                                          default=False)
     version = VersionProperty("1.1.1")

--- a/release.json
+++ b/release.json
@@ -2,6 +2,6 @@
   "nio/Logger": {
     "language": "Python",
     "url": "git://github.com/nio-blocks/logger.git",
-    "version": "1.1.1"
+    "version": "1.2.0"
   }
 }

--- a/release.json
+++ b/release.json
@@ -1,7 +1,7 @@
 {
   "nio/Logger": {
     "language": "Python",
-    "version": "1.1.1",
-    "url": "git://github.com/nio-blocks/logger.git"
+    "url": "git://github.com/nio-blocks/logger.git",
+    "version": "1.1.1"
   }
 }

--- a/spec.json
+++ b/spec.json
@@ -1,27 +1,27 @@
 {
   "nio/Logger": {
     "version": "1.1.1",
-    "description": "The Logger blocks outputs incoming signals into the terminal and system designer's logger panel.",
+    "description": "The _Logger_ block sends incoming signals to display in the terminal and System Designer's logger panel.",
     "categories": [
       "Signal Inspection"
     ],
     "properties": {
       "log_as_list": {
-        "title": "Log as a list",
+        "title": "Log as a List",
         "type": "BoolType",
-        "description": "Hidden property defaulted to `False`. Whether to log incoming signals as lists. The default behavior is to log lists of incoming signals one at a time. Setting this to True allows one to see if the block received multiple signals at once or multiple signals sequentially.",
+        "description": "Whether to log incoming signals as lists. Default is `False` and each incoming signal list is logged one signal at a time. Setting this to `True` logs signals grouped inside their list.",
         "default": false
       },
       "log_at": {
         "title": "Log At",
         "type": "SelectType",
-        "description": "The log level that incoming signals show up as in the logs. Default is INFO.",
+        "description": "The log level that determines the rank of log messages to display. Default is INFO.",
         "default": "INFO"
       },
       "log_hidden_attributes": {
         "title": "Log Hidden Attributes",
         "type": "BoolType",
-        "description": "If `True` (checked) the log output will include hidden (private) attributes denoted by a leading underscore (eg: `_signal_attribute`.",
+        "description": "If `True` (checked) the log output will include hidden (private) attributes denoted by a leading underscore (e.g., `_signal_attribute`.)",
         "default": false
       }
     },
@@ -36,8 +36,8 @@
         "description": "Force the logger block to log the configured phrase.",
         "params": {
           "phrase": {
-            "title": "phrase",
             "default": "Default phrase",
+            "title": "phrase",
             "allow_none": false
           }
         }

--- a/spec.json
+++ b/spec.json
@@ -1,6 +1,6 @@
 {
   "nio/Logger": {
-    "version": "1.1.1",
+    "version": "1.2.0",
     "description": "The _Logger_ block sends incoming signals to display in the terminal and System Designer's logger panel.",
     "categories": [
       "Signal Inspection"
@@ -10,7 +10,7 @@
         "title": "Log as a List",
         "type": "BoolType",
         "description": "Hidden property to log incoming signals as lists. Default is `True` and signals are grouped inside their list. Setting this to `False` logs one signal at a time.",
-        "default": false
+        "default": true
       },
       "log_at": {
         "title": "Log At",
@@ -33,14 +33,14 @@
     "outputs": {},
     "commands": {
       "log": {
-        "description": "Force the logger block to log the configured phrase.",
         "params": {
           "phrase": {
-            "default": "Default phrase",
+            "allow_none": false,
             "title": "phrase",
-            "allow_none": false
+            "default": "Default phrase"
           }
-        }
+        },
+        "description": "Force the logger block to log the configured phrase."
       }
     }
   }

--- a/spec.json
+++ b/spec.json
@@ -9,7 +9,7 @@
       "log_as_list": {
         "title": "Log as a List",
         "type": "BoolType",
-        "description": "Whether to log incoming signals as lists. Default is `False` and each incoming signal list is logged one signal at a time. Setting this to `True` logs signals grouped inside their list.",
+        "description": "Hidden property to log incoming signals as lists. Default is `True` and signals are grouped inside their list. Setting this to `False` logs one signal at a time.",
         "default": false
       },
       "log_at": {

--- a/tests/test_logger_block.py
+++ b/tests/test_logger_block.py
@@ -77,8 +77,8 @@ class TestLogger(NIOBlockTestCase):
         blk.logger = MagicMock()
         signal = Signal({"I <3": "n.io"})
         blk.process_signals([signal, signal])
-        blk.logger.info.assert_called_once_with([json.dumps(signal.to_dict()),
-                                                 json.dumps(signal.to_dict())])
+        blk.logger.info.assert_called_once_with(
+            '[{"I <3": "n.io"}, {"I <3": "n.io"}]')
         self.assertEqual(blk.logger.error.call_count, 0)
 
     def test_log_sorting(self):

--- a/tests/test_logger_block.py
+++ b/tests/test_logger_block.py
@@ -46,12 +46,12 @@ class TestLogger(NIOBlockTestCase):
         blk.logger = MagicMock()
         signal = Signal({"I <3": "n.io"})
         blk.process_signals([signal])
-        blk.logger.info.assert_called_once_with(json.dumps(signal.to_dict()))
+        blk.logger.info.assert_called_once_with('[{}]'.format(json.dumps(signal.to_dict())))
         self.assertEqual(blk.logger.error.call_count, 0)
 
     def test_list_process_signals(self):
         blk = Logger()
-        self.configure_block(blk, {})
+        self.configure_block(blk, {"log_as_list": False})
         blk.logger = MagicMock()
         signal = Signal({"I <3": "n.io"})
         blk.process_signals([signal, signal])
@@ -63,7 +63,7 @@ class TestLogger(NIOBlockTestCase):
 
     def test_exception_on_logging(self):
         blk = Logger()
-        self.configure_block(blk, {})
+        self.configure_block(blk, {"log_as_list": False})
         blk.logger = MagicMock()
         blk.logger.info.side_effect = Exception()
         signal = Signal({"I <3": "n.io"})
@@ -83,6 +83,7 @@ class TestLogger(NIOBlockTestCase):
 
     def test_log_sorting(self):
         blk = Logger()
+        self.configure_block(blk, {"log_as_list": False})
         self.configure_block(blk, {})
         blk.logger = MagicMock()
         signal1 = Signal({"I <3": "n.io",
@@ -104,7 +105,7 @@ class TestLogger(NIOBlockTestCase):
         blk.logger = MagicMock()
         signal = Signal({"_hidden": "hidden!", "not_hidden": "not hidden!"})
         blk.process_signals([signal])
-        blk.logger.info.assert_called_once_with(json.dumps(signal.to_dict(True),
-                                                           sort_keys=True))
+        blk.logger.info.assert_called_once_with('[{}]'.format(json.dumps(signal.to_dict(True),
+                                                           sort_keys=True)))
         self.assertEqual(blk.logger.error.call_count, 0)
         self.assertEqual(len(signal.to_dict(True)), 2)


### PR DESCRIPTION
It is very difficult to explain signals as lists of signals when they are not shown that way in the logger panel. This PR will allow lists of signals to show in the logger panel. 

- add log_as_list
- create test for format
- format

- tested and working in the System Designer's logger panel
- updated documentation